### PR TITLE
"FactoryBot" を省略できるように変更

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## 概要
- #18 


## やったこと
`FactoryBot.create` を呼ぶときに `FactoryBot` を省略できるようにした。